### PR TITLE
Änderung Wahlordnung

### DIFF
--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -38,7 +38,9 @@ Diese Wahlordnung gilt für alle Wahlen zum Fachschaftsrat IT-Systems Engineerin
 
 ## §5 Wahlrecht
 
-Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht.
+(1) Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht für den Fachschaftsrat.
+
+(2) Für die Studienkommission und den Prüfungsausschuss besitzen nur Studierende des Bachelor- oder Masterstudiengangs aktives und passives Wahlrecht.
 
 
 ## §6 Wahlausschuss


### PR DESCRIPTION
Ich schlage vor, die Wahlordnung wie angegeben anzupassen.
Enthaltene Änderungen:
- Anpassung an die aktuelle Grundordnung der Uni Potsdam
- Ein Mitglied der Studienkommission und das Mitglied im Prüfungsausschuss werden nicht mehr durch die Fachschaft, sondern durch den Fachschaftsrat aus dessen Mitte gewählt.
- Genauere Formulierung §10 (3).
- Wahlausschreibung spätestens drei statt zwei Wochen vor der Wahl.
