### PR TITLE
Vorschlag Änderung Wahlordnung

### DIFF
--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -1,6 +1,6 @@
 # Wahlordnung der Fachschaft IT-Systems Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Wahlordnung ist am 15.05.2014 durch Beschluss des Fachschaftsrates in Kraft getreten.
+Diese Wahlordnung ist am 16.05.2014 durch Beschluss des Fachschaftsrates in Kraft getreten.
 
 
 


### PR DESCRIPTION
Bei fehlenden Kandidaten für den Prüfungsausschuss muss das Amt vom neuen FSR übernommen werden.

Dieser Vorschlag steht zur Diskussion und bedarf eines Beschlusses mit Zwei-Drittel-Mehrheit durch den FSR.
