### PR TITLE
Vorschlag zur Änderung der Satzung und Einführung einer Geschäftsordnung

### DIFF
--- a/geschaeftsordnung.md
+++ b/geschaeftsordnung.md
@@ -1,0 +1,111 @@
+# Geschäftsordnung des Fachschaftsrates IT-Systems Engineering
+
+Diese Geschäftsordnung wurde am 04.04.2016 vom Fachschaftsrat beschlossen und tritt in Kraft, sobald die Satzung der Fachschaft IT-Systems Engineering nach einer entsprechenden Änderung die Einführung einer Geschäftsordnung vorsieht.
+
+
+
+##§ 1 Geltungsbereich
+
+Die Geschäftsordnung gilt für den Fachschaftsrat IT-Systems Engineering am Hasso-Plattner-Institut an der Universität Potsdam.
+
+
+##§ 2 Konstituierung
+
+(1) Der Fachschaftsrat tritt spätestens eine Woche nach der Bekanntgabe der Wahlergebnisse auf Einladung des Wahlausschusses zusammen.
+
+(2) Der Fachschaftsrat wählt aus seiner Mitte:
+
+1. einen Vorsitzenden und ggf. dessen Stellvertretenden
+2. einen Finanzreferenten und ggf. dessen Stellvertretenden
+3. einen Beauftragten für die Vernetzung mit den anderen Organen der Studierendenschaft im Sinne der Satzung der Studierendenschaft der Universität Potsdam
+
+(3) Die in (2) festgelegten Ämter können jeweils durch ein konstruktives Misstrauensvotum des Fachschaftsrates oder nach dem Rücktritt einer Person von diesem Amt neu vergeben werden.
+
+
+##§ 3 Aufgabenverteilung
+
+(1) Der Vorsitzende des Fachschaftsrates ist verantwortlich für die Sitzungsleitung gemäß § 5.
+
+(2) Der Finanzreferent verwaltet die Finanzen der Fachschaft gemäß den Beschlüssen des Fachschaftsrates. Er und der ggf. gewählte Stellvertretende sind zu einzeln Verfügungsberechtigten zu erklären. Der Finanzreferent sollte den Finanz-Workshop des Allgemeinen Studierendenausschusses der Universität Potsdam besuchen.
+
+(3) Zu Beginn jeder Sitzung ist vom Sitzungsleitenden ein Protokollführender festzulegen, der alle Beschlüsse der Sitzung und diskutierte Punkte in einem Protokoll festhält. Der Protokollführende muss persönlich anwesend sein. Weiteres regelt § 7.
+
+(4) Alle weiteren Kompetenzbereiche können intern durch Beschluss festgelegt werden.
+
+
+##§ 4 Anwesenheit
+
+Bei der Anwesenheit von Mitgliedern des Fachschaftsrates während seiner Sitzungen wird unterschieden:
+
+1. Persönliche Anwesenheit: Alle Mitglieder des Fachschaftsrates, die sich während der Sitzung am Ort der Sitzung befinden, gelten als persönlich anwesend.
+2. Anwesenheit: Alle Mitglieder des Fachschaftsrates, die während der Sitzung persönlich anwesend sind oder per Telefon oder anderweitiger Einrichtung zur Kommunikation, insbesondere Internet- oder Videotelefonie, teilnehmen, gelten als anwesend.
+
+
+##§ 5 Sitzungsleitung
+
+(1) Während jeder Sitzung muss ein persönlich anwesendes Mitglied die Sitzungsleitung innehaben.
+
+(2) Der Sitzungsleitende ist verantwortlich für die Einberufung der Sitzung, Verwaltung der Tagesordnung und Festlegung der Protokollführung.
+
+(3) Die Sitzungsleitung wird in der Regel vom Vorsitzenden oder dem stellvertreten Vorsitzenden wahrgenommen. Es steht ihnen frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen. Diese Entscheidung erhält per Mitteilung an den gesamten Fachschaftsrat Gültigkeit.
+
+ 
+##§ 6 Beschlüsse
+
+(1) Der Fachschaftsrat ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder anwesend ist, wobei mindestens zwei Mitglieder persönlich anwesend sein müssen.
+
+(2) Beschlüsse werden mit der einfachen Mehrheit aller gültigen von anwesenden Mitgliedern abgegebenen Stimmen gefasst. Gibt es mehr Enthaltungen als Ja- und Nein-Stimmen zusammengezählt, ist der Antrag mit einer Enthaltungsmehrheit abgelehnt. Bei Stimmengleichheit entscheidet die Stimme des Sitzungsleitenden.
+
+(3) Die Beschlüsse des Fachschaftsrates werden in Protokollen festgehalten.
+
+(4) In dringenden Fällen kann der Fachschaftsrat einen Beschluss im Umlaufverfahren per E-Mail fassen. Dazu stellen der Vorsitzende oder sein Stellvertreter einen ausformulierten Beschlussantrag. Alle Mitglieder des Fachschaftsrates können eine Stimme zum Beschlussantrag abgeben. Es zählt die zuerst abgegebene Stimme. Ein Umlaufbeschluss ist angenommen, sobald mehr als die Hälfte der Mitglieder des Fachschaftsrates dafür gestimmt haben. Der Beschluss ist im Protokoll der nächsten Sitzung nachzutragen.
+
+
+##§ 7 Sitzungsprotokolle
+
+(1) Das Protokoll jeder Sitzung muss mindestens die folgenden Punkte enthalten:
+
+1. Datum
+2. Anwesende Mitglieder
+3. Sitzungsleitender
+4. Protokollführender
+5. Beschreibung der Anträge und Beschlüsse mit genauen Abstimmungsergebnissen
+
+(2) Die Sitzungsprotokolle werden allen Mitgliedern des Fachschaftsrates unverzüglich nach der Sitzung zugänglich gemacht.
+
+(3) Wenn innerhalb von zwei Werktagen nach dem Tag der Sitzung keine Änderungswünsche beim Protokollführenden eingegangen sind, gilt das Protokoll als angenommen.
+
+(4) Angenommene Protokolle werden innerhalb der Vorlesungszeit spätestens nach drei Vorlesungstagen, sonst spätestens nach sieben Tagen durch den Sitzungsleitenden veröffentlicht.
+
+(5) Sitzungsprotokolle sind mindestens 3 Jahre aufzubewahren.
+
+
+##§ 8 Rücktritt, Nachrücker
+
+(1) Jedes Mitglied kann aus triftigen Gründen vom Fachschaftsrat zurücktreten. Der Rücktritt muss zusammen mit einer Begründung den restlichen Mitgliedern in Schriftform vorgelegt werden.
+
+(2) Ein Ausscheiden aus der Fachschaft bewirkt zwingend einen sofortigen Rücktritt.
+
+(3) Scheiden ein oder mehrere Mitglieder des Fachschaftsrates aus, so sollte eine entsprechende Anzahl neuer Mitglieder innerhalb eines Monats nachrücken. Dazu wird das Wahlergebnis der letzten Wahl herangezogen. Nachrückende müssen erst ihre Wahl annehmen, bevor sie Mitglied des Fachschaftsrates werden.
+
+(4) Sollten sich nicht ausreichend Nachrückende finden, kann der Fachschaftsrat mit Zwei-Drittel-Mehrheit eine der folgenden Alternativen beschließen:
+
+1. Neuwahl des gesamten Fachschaftsrates zum nächstmöglichen Zeitpunkt
+2. Weiterarbeit mit verringerter Mitgliedszahl, sofern der Fachschaftsrat weiterhin aus ausreichend vielen Mitgliedern besteht und sich der höheren Arbeitsbelastung gewachsen fühlt
+
+Findet sich für keine der Alternativen eine Zwei-Drittel-Mehrheit, so tritt Alternative 1 in Kraft.
+
+(5) Der Rücktritt alter Mitglieder und die Annahme neuer Mitglieder werden per E-Mail an die Fachschaft bekanntgegeben und treten damit in Kraft. Die Entscheidung muss von allen bisherigen Mitgliedern des Fachschaftsrates per Unterschrift zur Kenntnis genommen worden sein.
+
+(6) Ein zurückgetretenes Mitglied des Fachschaftsrates bleibt so lange kommissarisch im Amt, bis sein Nachrücker durch Annahme offiziell Mitglied des Fachschaftsrates ist oder der Fachschaftsrat die Weiterarbeit mit verringerter Mitgliedszahl nach (4) 2. beschließt. Die Entlastung der zurückgetretenen und nachgerückten Mitglieder geschieht mit der nächsten ordentlichen Vollversammlung.
+
+(7) Ein nachgerücktes Mitglied bleibt längstens bis zur nächsten regulären Wahl des Fachschaftsrates im Amt.
+
+(8) Treten Mitglieder des Fachschaftsrates zurück, die bis zu diesem Zeitpunkt ein gewähltes Amt innehatten, dann muss dieses Amt während der nächsten Sitzung neu vergeben werden.
+
+
+##§ 9 Änderung der Geschäftsordnung
+
+(1) Der Fachschaftsrat kann Änderungen dieser Geschäftsordnung mit einer Zwei-Drittel-Mehrheit aller Mitglieder beschließen.
+
+(2) Der Fachschaftsrat muss die Fachschaft innerhalb von drei Tagen nach dem Beschluss per E-Mail über Änderungen informieren. Die Änderungen treten am Tag nach ihrer Bekanntmachung in Kraft.

--- a/satzung.md
+++ b/satzung.md
@@ -1,23 +1,24 @@
 # Satzung der Fachschaft IT-Systems Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Satzung ist am 16.04.2015 durch Beschluss der Vollversammlung in Kraft getreten.
+Diese Satzung ist am XX.XX.2016 durch Beschluss der Vollversammlung in Kraft getreten.
 
 
 
-## §1 Geltungsbereich
+##§ 1 Geltungsbereich
 
 Alle Studierenden der Universität Potsdam im Studiengang IT-Systems Engineering sowie alle Promovierenden des Hasso-Plattner-Institutes sind Mitglieder der Fachschaft IT-Systems Engineering.
 
 
-## §2 Organe
+##§ 2 Organe
 
 Die Organe der Fachschaft sind:
 
 1. die Vollversammlung
-2. der Fachschaftsrat.
+2. der Fachschaftsrat
+3. der Wahlausschuss.
 
 
-## §3 Vollversammlung
+##§ 3 Vollversammlung
 
 (1) Die Vollversammlung der Fachschaft ist das oberste beschlussfassende Organ der Fachschaft. In der Vollversammlung haben alle Mitglieder der Fachschaft Sitz und Stimme.
 
@@ -25,12 +26,12 @@ Die Organe der Fachschaft sind:
 
 (3) Außerordentliche Vollversammlungen können durch den Fachschaftsrat oder durch mindestens 15 Mitglieder der Fachschaft einberufen werden. Verantwortlich für die Durchführung sind die einberufenden Personen.
 
-(4) Vollversammlungen müssen mindestens 14 Tage vorher durch Aushang und E-Mail an die Fachschaft angekündigt werden. Eine ordnungsgemäß angekündigte Vollversammlung ist beschlussfähig.
+(4) Vollversammlungen müssen mindestens 14 Tage vorher per E-Mail an die Fachschaft angekündigt werden. Eine ordnungsgemäß angekündigte Vollversammlung ist beschlussfähig.
 
 (5) Vollversammlungen dürfen nur während der Vorlesungszeit einberufen werden.
 
 
-## §4 Fachschaftsrat
+##§ 4 Fachschaftsrat
 
 (1) Der Fachschaftsrat ist beschlussfähiges und ausführendes Organ der Fachschaft. Er ist an die Satzung und an die Beschlüsse der Vollversammlung gebunden.
 
@@ -40,8 +41,10 @@ Die Organe der Fachschaft sind:
 
 (4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Dadurch treten die Regelungen entsprechend §4g in Kraft.
 
+(5) Der Fachschaftsrat gibt sich eine Geschäftsordnung.
 
-## §4a Aufgaben
+
+##§ 4a Aufgaben
 
 Zu den Aufgaben des Fachschaftsrates gehören insbesondere:
 
@@ -51,114 +54,34 @@ Zu den Aufgaben des Fachschaftsrates gehören insbesondere:
 4. Verwaltung der Finanzen der Fachschaft
 
 
-## §4b Konstituierung
-
-(1) Der Fachschaftsrat tritt spätestens eine Woche nach der Bekanntgabe der Wahlergebnisse auf Einladung des Wahlausschusses zusammen.
-
-(2) Der Fachschaftsrat wählt aus seiner Mitte
-
-1. einen Vorsitzenden und ggf. dessen Stellvertretenden
-2. einen Finanzreferenten und ggf. dessen Stellvertretenden
-
-(3) Die in (2) festgelegten Ämter können durch Beschluss mit einer Zwei-Drittel-Mehrheit auch innerhalb einer Amtszeit neu vergeben werden.
-
-
-## §4c Aufgabenverteilung
-
-(1) Der Vorsitzende des Fachschaftsrates ist verantwortlich für die Sitzungsleitung gemäß §4e. Er ist ohne weiteren Beschluss automatisch ebenfalls Beauftragter für die Vernetzung mit den anderen Organen der Studierendenschaft im Sinne der Satzung der Studierendenschaft der Universität Potsdam.
-
-(2) Der Finanzreferent verwaltet die Finanzen der Fachschaft gemäß den Beschlüssen des Fachschaftsrates. Er und der ggf. gewählte Stellvertretende sind zu einzeln Verfügungsberechtigten zu erklären. Der Finanzreferent sollte den Finanz-Workshop des Allgemeinen Studierendenausschusses der Universität Potsdam besuchen.
-
-(3) Alle weiteren Kompetenzbereiche können intern durch Beschluss festgelegt werden.
-
-
-## §4d Anwesenheit
-
-Bei der Anwesenheit von Mitgliedern des Fachschaftsrates während seiner Sitzungen gilt es zu unterscheiden:
-
-1. persönliche Anwesenheit: Alle Mitglieder des Fachschaftsrates, die sich während der Sitzung am Ort der Sitzung befinden, gelten als persönlich anwesend.
-2. Anwesenheit: Alle Mitglieder des Fachschaftsrates, die während der Sitzung persönlich anwesend sind oder per Telefon oder anderweitiger Einrichtung zur Kommunikation, insbesondere Internet- oder Videotelefonie, teilnehmen, gelten als anwesend.
-
-
-## §4e Sitzungsleitung
-
-(1) Während jeder Sitzung muss ein persönlich anwesendes Mitglied die Sitzungsleitung innehaben.
-
-(2) Der Sitzungsleitende ist verantwortlich für die Einberufung der Sitzung, Verwaltung der Tagesordnung und Festlegung der Protokollführung.
-
-(3) Die Sitzungsleitung wird in der Regel vom Vorsitzenden oder dem stellvertreten Vorsitzenden wahrgenommen. Es steht ihnen frei, die Sitzungsleitung für die betreffende Sitzung einstimmig auf ein anderes Mitglied zu übertragen. Diese Entscheidung erhält per Mitteilung an den gesamten Fachschaftsrat Gültigkeit.
-
- 
-## §4f Beschlüsse
-
-(1) Der Fachschaftsrat ist beschlussfähig, wenn mindestens die Hälfte seiner Mitglieder anwesend ist, wobei mindestens zwei Mitglieder persönlich anwesend sein müssen.
-
-(2) Die Beschlüsse werden mit der einfachen Mehrheit aller gültigen von anwesenden Mitgliedern abgegebenen Stimmen gefasst. Bei Stimmengleichheit entscheidet die Stimme des Sitzungsleitenden.
-
-(3) Die Beschlüsse des Fachschaftsrates werden in Protokollen festgehalten.
-
-
-## §4g Sitzungen
+##§ 4b Sitzungen
 
 (1) Der Fachschaftsrat soll während der Vorlesungszeit jede Woche zusammentreten. Der Termin der turnusmäßigen Sitzungen ist durch eine E-Mail an die Fachschaft bekanntzugeben.
 
 (2) Zu außerordentlichen Sitzungen muss eine Einladung per E-Mail an die Fachschaft erfolgen.
 
-(3) Zu Beginn jeder Sitzung ist vom Sitzungsleitenden ein Protokollführender festzulegen, der alle Beschlüsse der Sitzung und diskutierte Punkte in einem Protokoll festhält. Der Protokollführende muss persönlich anwesend sein. Weiteres regelt §4h.
+(3) Auf den Sitzungen ist ein Protokoll zu führen.
 
 (4) Die Sitzungen des Fachschaftsrates sind offen für alle Mitglieder der Fachschaft. Auf Beschluss kann die Öffentlichkeit ausgeschlossen werden. Inhalte von nicht öffentlichen Sitzungsteilen sind in gesonderten Protokollen festzuhalten, auf die mit einer Begründung für die Geheimhaltung im regulären Protokoll verwiesen wird.
 
-
-## §4h Sitzungsprotokolle
-
-(1) Das Protokoll jeder Sitzung muss mindestens die folgenden Punkte enthalten:
-
-1. Datum
-2. Anwesende Mitglieder
-3. Sitzungsleitender
-4. Protokollführender
-5. Beschreibung der Anträge und Beschlüsse mit genauen Abstimmungsergebnissen
-
-(2) Die Sitzungsprotokolle werden allen Mitgliedern des Fachschaftsrates unverzüglich nach der Sitzung zugänglich gemacht.
-
-(3) Wenn innerhalb von zwei Werktagen nach dem Tag der Sitzung keine Änderungswünsche beim Protokollführenden eingegangen sind, gilt das Protokoll als angenommen.
-
-(4) Angenommene Protokolle werden innerhalb der Vorlesungszeit spätestens nach drei Vorlesungstagen, sonst spätestens nach sieben Tagen durch den Sitzungsleitenden veröffentlicht.
-
-(5) Sitzungsprotokolle sind mindestens 3 Jahre aufzubewahren.
+(5) Näheres regelt die Geschäftsordnung des Fachschaftsrates.
 
 
-## §4i Rücktritt, Nachrücker
+##§ 5 Wahlausschuss
+(1) Dem Wahlausschuss obliegt die ordnungsgemäße Vorbereitung und Durchführung der Wahlen zum Fachschaftsrat.
 
-(1) Jedes Mitglied kann aus triftigen Gründen vom Fachschaftsrat zurücktreten. Der Rücktritt muss zusammen mit einer Begründung den restlichen Mitgliedern in Schriftform vorgelegt werden.
+(2) Der Wahlausschuss wird durch den Fachschaftsrat aus der Mitte der Fachschaft gebildet.
 
-(2) Ein Ausscheiden aus der Fachschaft bewirkt zwingend einen sofortigen Rücktritt.
-
-(3) Scheiden ein oder mehrere Mitglieder des Fachschaftsrates aus, so sollte eine entsprechende Anzahl neuer Mitglieder innerhalb eines Monats nachrücken. Dazu wird das Wahlergebnis der letzten Wahl herangezogen. Nachrückende müssen erst ihre Wahl annehmen, bevor sie Mitglied des Fachschaftsrates werden.
-
-(4) Sollten sich nicht ausreichend Nachrückende finden, kann der Fachschaftsrat mit Zwei-Drittel-Mehrheit eine der folgenden Alternativen beschließen:
-
-1. Neuwahl des gesamten Fachschaftsrates zum nächstmöglichen Zeitpunkt
-2. Weiterarbeit mit verringerter Mitgliedszahl, sofern der Fachschaftsrat weiterhin aus ausreichend vielen Mitgliedern besteht und sich der höheren Arbeitsbelastung gewachsen fühlt
-
-Findet sich für keine der Alternativen eine Zwei-Drittel-Mehrheit, so tritt Alternative 1 in Kraft.
-
-(5) Der Rücktritt alter Mitglieder und die Annahme neuer Mitglieder werden per Aushang sowie E-Mail an die Fachschaft bekanntgegeben und treten damit in Kraft. Die Entscheidung muss von allen bisherigen Mitgliedern des Fachschaftsrates per Unterschrift zur Kenntnis genommen worden sein.
-
-(6) Ein zurückgetretenes Mitglied des Fachschaftsrates bleibt so lange kommissarisch im Amt, bis sein Nachrücker durch Annahme offiziell Mitglied des Fachschaftsrates ist oder der Fachschaftsrat die Weiterarbeit mit verringerter Mitgliedszahl nach §4i (4) 2. beschließt. Die Entlastung der zurückgetretenen und nachgerückten Mitglieder geschieht mit der nächsten ordentlichen Vollversammlung.
-
-(7) Ein nachgerücktes Mitglied bleibt längstens bis zur nächsten regulären Wahl des Fachschaftsrates im Amt.
-
-(8) Treten Mitglieder des Fachschaftsrates zurück, die bis zu diesem Zeitpunkt ein gewähltes Amt innehatten, dann muss dieses Amt während der nächsten Sitzung neu vergeben werden.
+(3) Näheres regelt die Wahlordnung der Fachschaft IT-Systems Engineering.
 
 
-## §5 Finanzen
+##§ 6 Finanzen
 
-(1) Über die Verwendung der Mittel für die Fachschaft aus dem Haushaltsplan der Studentenschaft muss ein Plan zu Beginn des Haushaltsjahres beschlossen werden.
+(1) Über die Verwendung der Mittel für die Fachschaft aus dem Haushaltsplan der Studierendenschaft muss der Fachschaftsrat zu Beginn des Haushaltsjahres einen Haushaltsplan beschließen.
 
 (2) Über die Verwendung der Mittel ist Nachweis zu führen.
 
 
-## §6 Satzungsänderungen
+##§ 7 Satzungsänderungen
 
 Die Änderung der Satzung kann nur erfolgen, wenn zwei Drittel der bei einer Vollversammlung stimmberechtigten Anwesenden dem Antrag zustimmen.


### PR DESCRIPTION
### Satzung (durch die Vollversammlung zu beschließen)
- §§ 4b bis 4f, 4h und 4i werden aus der Satzung in eine neue Geschäftsordnung verschoben
- der Absatz zur Protokollführung aus § 4b Sitzungen (bisher § 4g) wird in die Geschäftsordnung verschoben, es wird nur das Anfertigen von Protokollen festgeschrieben
- der Wahlausschuss wird als Organ aufgeführt und erhält einen eigenen Paragraphen
- Aushänge sind nicht mehr nötig, alle Informationen können per E-Mail versandt werden

### Geschäftsordnung (durch den Fachschaftsrat beschlossen, tritt nach der Satzungsänderung in Kraft)
- enthält die §§ 4b bis 4f, 4h und 4i der bisherigen Satzung und den Absatz zur Protokollführung aus dem bisherigen § 4g
- der Vernetzungsbeauftragte wird nun auf der konstituierenden Sitzung gewählt
- Ämter innerhalb des FSRs können durch konstruktives Misstrauensvotum oder nach Rücktritt einer Person von einem Amt neu vergeben werden (bisher war eine Zweidrittelmehrheit nötig)
- neue Regelung zur Enthaltungsmehrheit
- neue Regelung zu Umlaufbeschlüssen