### PR TITLE
Änderung der Wahlordnung

### DIFF
--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -1,6 +1,6 @@
 # Wahlordnung der Fachschaft IT-Systems Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Wahlordnung ist am 28.05.2014 durch Beschluss des Fachschaftsrates in Kraft getreten.
+Diese Wahlordnung ist am 23.01.2017 durch Beschluss des Fachschaftsrates in Kraft getreten.
 
 
 
@@ -15,18 +15,18 @@ Diese Wahlordnung gilt für alle Wahlen zum Fachschaftsrat IT-Systems Engineerin
 
 (2) Gemäß Artikel 23 (3) der Grundordnung der Universität Potsdam vom 27. Februar 2013 werden drei studentische Mitglieder in die Studienkommission gewählt. Zwei der Mitglieder werden von der gesamten Fachschaft gewählt, das dritte Mitglied wählt der Fachschaftsrat aus seiner Mitte.
 
-(3) Es wird ein studentisches Mitglied in den Prüfungsausschuss gewählt.
+(3) Gemäß § 2 (1) der Allgemeinen Studien- und Prüfungsordnung für die nicht lehramtsbezogenen Bachelor- und Masterstudiengänge an der Universität Potsdam (BAMA-O) wird ein studentisches Mitglied in den Prüfungsausschuss gewählt.
 
 
 ## § 3 Amtszeit und Wahltermin
 
-(1) Der Fachschaftsrat sowie die von der Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss werden für ein Jahr gewählt und bleiben kommissarisch über den Wahlzeitraum hinaus im Amt, bis die Gremien neu gewählt wurden. Ausnahmen hiervon bilden Rücktritte und Nachrücker im Fachschaftsrat gemäß Satzung.
+(1) Der Fachschaftsrat sowie die studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss werden für ein Jahr gewählt und bleiben darüber hinaus bis zum Amtsantritt der neu gewählten Mitglieder kommissarisch im Amt.
 
-(2) Die Amtszeit der gewählten Mitglieder beginnt unmittelbar nach Feststellung des Wahlergebnisses. Gleichzeitig endet die Amtszeit der bisherigen Mitglieder.
+(2) Die Amtszeit der gewählten Mitglieder aller Gremien beginnt zur konstituierenden Sitzung des Fachschaftsrates. Gleichzeitig endet die Amtszeit der bisherigen Mitglieder.
 
 (3) Die Wahlen finden gewöhnlich zu Beginn der Vorlesungszeit jedes Sommersemesters statt, spätestens aber einen Monat nach Vorlesungsbeginn. Im Falle einer Neuwahl vor Ablauf einer vollständigen Legislaturperiode ist dieser Zeitpunkt entsprechend anzupassen.
 
-(4) Die Wahl des studentischen Mitglieds in der Studienkommission, das durch den Fachschaftsrat gewählt wird, findet während dessen konstituierender Sitzung statt. Die §§ 4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in § 5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
+(4) Die Wahl des durch den Fachschaftsrat zu wählenden studentischen Mitglieds in der Studienkommission findet während der konstituierenden Sitzung des Fachschaftsrates statt. Die §§ 4 bis 12 finden dabei keine Anwendung. Das angewandte Verfahren wird in der Geschäftsordnung des Fachschaftsrates IT-Systems Engineering geregelt. Die Fachschaft ist über das gewählte Mitglied zu benachrichtigen.
 
 (5) Als Zeitraum der Wahlen ist die Zeit zwischen Einberufung des Wahlausschusses und Ablauf der Anfechtungsfrist zu verstehen.
 
@@ -55,7 +55,7 @@ Diese Wahlordnung gilt für alle Wahlen zum Fachschaftsrat IT-Systems Engineerin
 
 (4) Mitglieder des Wahlausschusses können nicht für die Wahlen kandidieren.
 
-(5) Der Wahlausschuss kann Wahlhelfer bestimmen. Diese müssen nicht der Fachschaft angehören.
+(5) Der Wahlausschuss kann weitere Personen zur Unterstützung während der Wahlhandlung und Auszählung heranziehen. Diese müssen nicht der Fachschaft angehören.
 
 (6) Der Fachschaftsrat muss dem Wahlausschuss alle zur Vorbereitung und Durchführung der Wahlen notwendigen Materialien zur Verfügung stellen.
 
@@ -64,54 +64,60 @@ Diese Wahlordnung gilt für alle Wahlen zum Fachschaftsrat IT-Systems Engineerin
 
 (1) Der Wahlausschuss schreibt die Wahlen zum Fachschaftsrat sowie für zwei studentische Mitglieder in der Studienkommission und ein studentisches Mitglied im Prüfungsausschuss spätestens drei Wochen vor der Wahl aus. Die Wahlbekanntmachung ist durch E-Mail an die Fachschaft zu veröffentlichen.
 
-(2) Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in §11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Hinweise enthalten. 
+(2) Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in § 11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Hinweise beinhalten und muss auf die in § 9 (5) festgelegte Handhabung von Personen gleichen Namens hinweisen. 
 
 
 ## § 8 Wahlvorschläge
 
-(1) Die Kandidatur für den Fachschaftsrat sowie für die durch die Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss erfolgt in Textform. Die Mitteilung über die Kandidatur ist spätestens zwei Wochen vor der Wahl dem Wahlausschuss zuzuleiten. Sie muss Namen und Vornamen, E-Mail-Adresse, Studiengang und falls zutreffend Semesterzahl des Kandidaten enthalten.
+(1) Die Kandidatur für den Fachschaftsrat sowie für die durch die Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss erfolgt in Textform. Die Mitteilung über die Kandidatur ist spätestens zwei Wochen vor der Wahl dem Wahlausschuss zuzuleiten. Sie muss Namen und Vornamen, E-Mail-Adresse, Studiengang und falls zutreffend Semesterzahl der kandidierenden Person enthalten.
 
 (2) Der Wahlausschuss kann eine Verlängerung der Zuleitungsfrist der Wahlvorschläge beschließen, spätestens endet diese aber eine Woche vor der Wahl.
 
-(3) Die Wahlvorschläge werden eine Woche vor der Wahl per E-Mail an die Fachschaft bekanntgegeben.
+(3) Die Wahlvorschläge werden spätestens eine Woche vor der Wahl per E-Mail an die Fachschaft bekanntgegeben.
 
 
-## § 8a Fehlende Kandidaten bei der Wahl zum Prüfungsausschuss
+## § 8a Fehlende Kandidaturen bei der Wahl zum Prüfungsausschuss
 
-(1) Gibt es für die Wahl für das studentische Mitglied im Prüfungsausschuss keinen Kandidaten und hat bis zum Beginn der Stimmabgabe keine wahlberechtigte Person gegenüber der Fachschaft zu verstehen gegeben, für das Amt zur Verfügung zu stehen, so findet abweichend von § 2 (3) keine Wahl für das studentische Mitglied im Prüfungsausschuss durch die gesamte Fachschaft statt.
+(1) Gibt es für die Wahl für das studentische Mitglied im Prüfungsausschuss keine Kandidatur und hat bis zum Beginn der Stimmabgabe keine wahlberechtigte Person gegenüber der Fachschaft zu verstehen gegeben, für das Amt zur Verfügung zu stehen, so findet abweichend von § 2 (3) keine Wahl für das studentische Mitglied im Prüfungsausschuss durch die gesamte Fachschaft statt.
 
 (2) Das Amt muss in diesem Fall von einem Mitglied des Fachschaftsrates übernommen werden.
 
-(3) Die Wahl des studentischen Mitglieds im Prüfungsausschuss findet in diesem Fall während der konstituierenden Sitzung des neuen Fachschaftsrates statt. Die §§ 4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in §5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
+(3) Die Wahl des studentischen Mitglieds im Prüfungsausschuss findet in diesem Fall analog zur in § 3 (4) geregelten Wahl des vom Fachschaftsrat gewählten studentischen Mitglieds in der Studienkommission statt.
 
 
 ## § 9 Wahldurchführung
 
-(1) Jedes Mitglied der Fachschaft hat ebenso viele Stimmen, wie Mitglieder des jeweiligen Gremiums zu wählen sind.
+(1) Jedes Mitglied der Fachschaft hat ebenso viele Stimmen, wie Mitglieder des jeweiligen Gremiums zu wählen sind. Stimmenhäufung ist nicht zulässig.
 
-(2) Dem Wähler steht es offen, seine Stimmen auf die Kandidaten zu verteilen. Stimmenhäufung ist nicht zulässig.
+(2) Wählende sind nicht an die Wahlvorschläge gebunden.
 
-(3) Der Wähler ist nicht an die Kandidaten gebunden.
+(3) Wahlberechtigten wird ab der Bekanntgabe der Wahlvorschläge die Möglichkeit gegeben, ihre Stimme per E-Mail abzugeben. Dieses Verfahren muss einer Briefwahl insofern entsprechen, als abgegebene Stimmen der wählenden Person nicht zugeordnet werden dürfen. Dafür ist die Stimmabgabe für jedes zu wählende Gremium einzeln in getrennt von der E-Mail auszuwertenden Anhängen zu tätigen. Die Abgabe der Stimmen per E-Mail muss vom HPI-Konto erfolgen. Der Wahlausschuss wertet nur Anhänge für Gremien aus, für welche die sendende Person das aktive Wahlrecht besitzt.
 
-(4) Wahlberechtigten wird ab der Bekanntgabe der Kandidaten die Möglichkeit gegeben, ihre Stimme per E-Mail abzugeben. Dieses Verfahren muss einer Briefwahl insofern entsprechen, als abgegebene Stimmen dem Wähler nicht zugeordnet werden dürfen. Dafür ist die Stimmabgabe in einem getrennt von der E-Mail auszuwertenden Anhang zu tätigen. Die Abgabe der Stimmen per E-Mail muss vom HPI-Konto des Wählers erfolgen.
+(4) Wenn eine Person sowohl per E-Mail als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der E-Mail.
 
-(5) Sofern ein Wähler sowohl per E-Mail als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der E-Mail.
+(5) Bei mehreren Personen gleichen Namens wird für die Stimmabgabe der in der HPI-Domäne geführte Name mit nachgestellter Zahl verwendet. Der Wahlausschuss weist in der Wahlausschreibung und zur Eröffnung der Wahl darauf hin.
 
 
 ## § 10 Ergebnisfeststellung
 
-(1) Nach Abschluss der Wahl stellt der Wahlausschuss die Zahl der für jeden Kandidaten abgegebenen Stimmen fest. Die Stimmenauszählung erfolgt spätestens am dritten Vorlesungstag nach der Wahl. Sie erfolgt öffentlich für alle Mitglieder der Fachschaft und muss durch den Wahlausschuss spätestens zwei Tage vorher per E-Mail an die Fachschaft angekündigt werden.
+(1) Nach Abschluss der Wahl stellt der Wahlausschuss fest, für welche Person wie viele Stimmen abgegeben wurden. Die Stimmenauszählung erfolgt direkt im Anschluss an die Wahl oder am nächsten auf die Wahl folgenden Vorlesungstag. Sie erfolgt öffentlich für alle Mitglieder der Fachschaft und muss durch den Wahlausschuss spätestens zwei Tage vor der Wahl per E-Mail an die Fachschaft angekündigt werden.
 
-(2) In den Fachschaftsrat, die Studienkommission und den Prüfungsausschuss gewählt sind die Personen, die jeweils die meisten Stimmen auf sich vereinen. Sind weniger als die notwendige Anzahl Personen gewählt, sind Neuwahlen notwendig.
+(2) In den Fachschaftsrat, die Studienkommission und den Prüfungsausschuss gewählt sind die Personen, die jeweils die meisten Stimmen auf sich vereinen. Sind weniger als die notwendige Anzahl Personen gewählt, sind Neuwahlen für das jeweilige Gremium notwendig.
 
-(3) Bei Stimmengleichheit um den letzten Platz entstehen im Fachschaftsrat Überhangmandate. Bei Stimmengleichheit in den Wahlen für die studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss müssen sich die betroffenen Kandidaten mit gleicher Stimmenzahl zusammen mit dem Wahlausschuss auf ein Lösungsverfahren einigen.
+(3) Bei Stimmengleichheit um den letzten Platz entstehen im Fachschaftsrat Überhangmandate. Bei Stimmengleichheit in den Wahlen für die studentischen Mitglieder in der Studienkommission oder dem Prüfungsausschuss müssen sich die betroffenen Personen mit gleicher Stimmenzahl zusammen mit dem Wahlausschuss auf ein Lösungsverfahren einigen.
 
-(4) Jede gewählte Person muss dem Wahlausschuss innerhalb einer Woche mitteilen, ob er oder sie die Wahl annimmt. Ansonsten gilt die Annahme als verweigert.
+(4) Der Wahlausschuss informiert nach Abschluss der Auszählung umgehend alle gewählten Personen und fragt sie nach Annahme der Wahl.
+
+(5) Die Annahme muss dem Wahlausschuss innerhalb von vier Tagen nach dem Tag der Wahl mitgeteilt werden. Ansonsten gilt die Annahme als verweigert.
 
 
 ## § 11 Bekanntgabe des Wahlergebnisses
 
-Der Wahlausschuss gibt die Ergebnisse der Wahl per E-Mail an die Fachschaft bekannt. Er benachrichtigt ferner die gewählten Mitglieder des jeweiligen Gremiums.
+(1) Der Wahlausschuss gibt die Ergebnisse der Wahl spätestens einen Vorlesungstag nach der Annahme aller Mitglieder per E-Mail an die Fachschaft bekannt. Er benachrichtigt ferner die gewählten Mitglieder des jeweiligen Gremiums.
+
+(2) Der Wahlausschuss lädt die in den Fachschaftsrat gewählten Mitglieder zu einem spätestens eine Woche nach der Bekanntgabe der Wahlergebnisse liegenden Termin zur konstituierenden Sitzung ein.
+
+(3) Die in die Studienkommission und den Prüfungsausschuss gewählten Mitglieder werden vom Wahlausschuss gebeten, ebenfalls an der konstituierenden Sitzung des Fachschaftsrates teilzunehmen.
 
 
 ## § 12 Anfechtungsfrist
@@ -121,14 +127,31 @@ Der Wahlausschuss gibt die Ergebnisse der Wahl per E-Mail an die Fachschaft beka
 (2) Über Zulässigkeit und Folgen der Anfechtung entscheidet der Wahlausschuss.
 
 
-## § 13 Wahlordnung der Universität Potsdam
+## § 13 Rücktritte und Nachrückverfahren
+
+(1) Jedes Mitglied eines Gremiums kann aus triftigen Gründen von einem gewählten Amt zurücktreten. Der Rücktritt muss zusammen mit einer Begründung dem Fachschaftsrat in Schriftform vorgelegt werden.
+
+(2) Ein Ausscheiden aus der Fachschaft bewirkt zwingend einen sofortigen Rücktritt der Person aus allen Gremien. Dies ist dem Fachschaftsrat unverzüglich mitzuteilen.
+
+(3) Verliert eine Person das passive Wahlrecht, bleibt sie in ihrem Amt, solange sie weiterhin Mitglied der Fachschaft ist.
+
+(4) Rücktritte im Fachschaftsrat werden gemäß der Geschäftsordnung des Fachschaftsrates IT-Systems Engineering gehandhabt.
+
+(5) Tritt ein Mitglied des Fachschaftsrates zurück, das vom Fachschaftsrat in die Studienkommission oder den Prüfungsausschuss gewählt wurde, scheidet die Person damit auch aus diesen Gremien aus.
+
+(6) Scheiden ein oder mehrere gewählte Mitglieder anderer Gremien aus, so rückt eine entsprechende Anzahl neuer Mitglieder nach. Wurde das ausgeschiedene Mitglied von der gesamten Fachschaft gewählt, wird dazu das Wahlergebnis der letzten Wahl herangezogen. Findet sich dadurch kein neues Mitglied oder wurde das Mitglied vom Fachschaftsrat gewählt, wählt der Fachschaftsrat das neue Mitglied auf seiner nächsten Sitzung aus seiner Mitte.
+
+(7) Der Fachschaftsrat verantwortet die Nachrückverfahren und nimmt die Annahme der nachrückenden Personen entgegen. Die Fachschaft ist über alle Mitgliedsänderungen zu benachrichtigen.
+
+
+## § 14 Wahlordnung der Universität Potsdam
 
 (1) Diese Wahlordnung ist im Zweifel im Sinne der Bestimmungen der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam auszulegen.
 
 (2) Soweit diese Wahlordnung eine Regelung nicht enthält, die unabdingbar ist und nicht durch Auslegung ermittelt werden kann, sind die Vorschriften der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam entsprechend anzuwenden.
 
 
-## § 14 Änderung der Wahlordnung
+## § 15 Änderung der Wahlordnung
 
 (1) Der Fachschaftsrat kann Veränderungen dieser Wahlordnung vornehmen. Ein entsprechender Beschluss bedarf einer Zwei-Drittel-Mehrheit aller Mitglieder des Fachschaftsrates.
 

--- a/wahlordnung.md
+++ b/wahlordnung.md
@@ -4,131 +4,131 @@ Diese Wahlordnung ist am 28.05.2014 durch Beschluss des Fachschaftsrates in Kraf
 
 
 
-## §1 Geltungsbereich
+## § 1 Geltungsbereich
 
 Diese Wahlordnung gilt für alle Wahlen zum Fachschaftsrat IT-Systems Engineering sowie für die studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss am Hasso-Plattner-Institut an der Universität Potsdam.
 
 
-## §2 Gremien
+## § 2 Gremien
 
-(1)	In den Fachschaftsrat werden gemäß Satzung der Fachschaft IT-Systems Engineering acht Mitglieder gewählt.
+(1) In den Fachschaftsrat werden gemäß Satzung der Fachschaft IT-Systems Engineering acht Mitglieder gewählt.
 
-(2)	Gemäß Artikel 23 (3) der Grundordnung der Universität Potsdam vom 27. Februar 2013 werden drei studentische Mitglieder in die Studienkommission gewählt. Zwei der Mitglieder werden von der gesamten Fachschaft gewählt, das dritte Mitglied wählt der Fachschaftsrat aus seiner Mitte.
+(2) Gemäß Artikel 23 (3) der Grundordnung der Universität Potsdam vom 27. Februar 2013 werden drei studentische Mitglieder in die Studienkommission gewählt. Zwei der Mitglieder werden von der gesamten Fachschaft gewählt, das dritte Mitglied wählt der Fachschaftsrat aus seiner Mitte.
 
-(3)	Es wird ein studentisches Mitglied in den Prüfungsausschuss gewählt.
+(3) Es wird ein studentisches Mitglied in den Prüfungsausschuss gewählt.
 
 
-## §3 Amtszeit und Wahltermin
+## § 3 Amtszeit und Wahltermin
 
-(1)	Der Fachschaftsrat sowie die von der Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss werden für ein Jahr gewählt und bleiben kommissarisch über den Wahlzeitraum hinaus im Amt, bis die Gremien neu gewählt wurden. Ausnahmen hiervon bilden Rücktritte und Nachrücker im Fachschaftsrat gemäß Satzung.
+(1) Der Fachschaftsrat sowie die von der Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss werden für ein Jahr gewählt und bleiben kommissarisch über den Wahlzeitraum hinaus im Amt, bis die Gremien neu gewählt wurden. Ausnahmen hiervon bilden Rücktritte und Nachrücker im Fachschaftsrat gemäß Satzung.
 
-(2)	Die Amtszeit der gewählten Mitglieder beginnt unmittelbar nach Feststellung des Wahlergebnisses. Gleichzeitig endet die Amtszeit der bisherigen Mitglieder.
+(2) Die Amtszeit der gewählten Mitglieder beginnt unmittelbar nach Feststellung des Wahlergebnisses. Gleichzeitig endet die Amtszeit der bisherigen Mitglieder.
 
-(3)	Die Wahlen finden gewöhnlich zu Beginn der Vorlesungszeit jedes Sommersemesters statt, spätestens aber einen Monat nach Vorlesungsbeginn. Im Falle einer Neuwahl vor Ablauf einer vollständigen Legislaturperiode ist dieser Zeitpunkt entsprechend anzupassen.
+(3) Die Wahlen finden gewöhnlich zu Beginn der Vorlesungszeit jedes Sommersemesters statt, spätestens aber einen Monat nach Vorlesungsbeginn. Im Falle einer Neuwahl vor Ablauf einer vollständigen Legislaturperiode ist dieser Zeitpunkt entsprechend anzupassen.
 
-(4) Die Wahl des studentischen Mitglieds in der Studienkommission, das durch den Fachschaftsrat gewählt wird, findet während dessen konstituierender Sitzung statt. Die §§4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in §5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
+(4) Die Wahl des studentischen Mitglieds in der Studienkommission, das durch den Fachschaftsrat gewählt wird, findet während dessen konstituierender Sitzung statt. Die §§ 4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in § 5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
 
 (5) Als Zeitraum der Wahlen ist die Zeit zwischen Einberufung des Wahlausschusses und Ablauf der Anfechtungsfrist zu verstehen.
 
 
-## §4 Wahlgrundsatz
+## § 4 Wahlgrundsatz
 
-(1)	Die Wahlen der Fachschaft erfolgen in freier, gleicher, unmittelbarer und geheimer Wahl.
+(1) Die Wahlen der Fachschaft erfolgen in freier, gleicher, unmittelbarer und geheimer Wahl.
 
-(2)	Es findet eine Mehrheitswahl statt.
+(2) Es findet eine Mehrheitswahl statt.
 
 
-## §5 Wahlrecht
+## § 5 Wahlrecht
 
 (1) Jedes Mitglied der Fachschaft besitzt das aktive und passive Wahlrecht für den Fachschaftsrat.
 
 (2) Für die Studienkommission und den Prüfungsausschuss besitzen nur Studierende des Bachelor- oder Masterstudiengangs aktives und passives Wahlrecht.
 
 
-## §6 Wahlausschuss
+## § 6 Wahlausschuss
 
-(1)	Dem Wahlausschuss obliegt die ordnungsgemäße Vorbereitung und Durchführung der Wahlen derjenigen Mitglieder, die nicht durch den Fachschaftsrat gewählt werden.
+(1) Dem Wahlausschuss obliegt die ordnungsgemäße Vorbereitung und Durchführung der Wahlen derjenigen Mitglieder, die nicht durch den Fachschaftsrat gewählt werden.
 
-(2)	Der Wahlausschuss wird spätestens sechs Wochen vor dem geplanten Wahltermin durch den Fachschaftsrat aus der Mitte der Fachschaft gebildet.
+(2) Der Wahlausschuss wird spätestens sechs Wochen vor dem geplanten Wahltermin durch den Fachschaftsrat aus der Mitte der Fachschaft gebildet.
 
-(3)	Der Wahlausschuss umfasst mindestens drei Personen.
+(3) Der Wahlausschuss umfasst mindestens drei Personen.
 
-(4)	Mitglieder des Wahlausschusses können nicht für die Wahlen kandidieren.
+(4) Mitglieder des Wahlausschusses können nicht für die Wahlen kandidieren.
 
-(5)	Der Wahlausschuss kann Wahlhelfer bestimmen. Diese müssen nicht der Fachschaft angehören.
+(5) Der Wahlausschuss kann Wahlhelfer bestimmen. Diese müssen nicht der Fachschaft angehören.
 
-(6)	Der Fachschaftsrat muss dem Wahlausschuss alle zur Vorbereitung und Durchführung der Wahlen notwendigen Materialien zur Verfügung stellen.
-
-
-## §7 Wahlausschreibung
-
-(1)	Der Wahlausschuss schreibt die Wahlen zum Fachschaftsrat sowie für zwei studentische Mitglieder in der Studienkommission und ein studentisches Mitglied im Prüfungsausschuss spätestens drei Wochen vor der Wahl aus. Die Wahlbekanntmachung ist durch E-Mail an die Fachschaft zu veröffentlichen.
-
-(2)	Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in §11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Hinweise enthalten. 
+(6) Der Fachschaftsrat muss dem Wahlausschuss alle zur Vorbereitung und Durchführung der Wahlen notwendigen Materialien zur Verfügung stellen.
 
 
-## §8 Wahlvorschläge
+## § 7 Wahlausschreibung
 
-(1)	Die Kandidatur für den Fachschaftsrat sowie für die durch die Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss erfolgt in Textform. Die Mitteilung über die Kandidatur ist spätestens zwei Wochen vor der Wahl dem Wahlausschuss zuzuleiten. Sie muss Namen und Vornamen, E-Mail-Adresse, Studiengang und falls zutreffend Semesterzahl des Kandidaten enthalten.
+(1) Der Wahlausschuss schreibt die Wahlen zum Fachschaftsrat sowie für zwei studentische Mitglieder in der Studienkommission und ein studentisches Mitglied im Prüfungsausschuss spätestens drei Wochen vor der Wahl aus. Die Wahlbekanntmachung ist durch E-Mail an die Fachschaft zu veröffentlichen.
 
-(2)	Der Wahlausschuss kann eine Verlängerung der Zuleitungsfrist der Wahlvorschläge beschließen, spätestens endet diese aber eine Woche vor der Wahl.
-
-(3)	Die Wahlvorschläge werden eine Woche vor der Wahl per E-Mail an die Fachschaft bekanntgegeben.
+(2) Die Wahlbekanntmachung informiert über Zeitpunkt, Ort und weitere Modalitäten der Wahlen. Sie sollte die in §11 der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Hinweise enthalten. 
 
 
-## §8a Fehlende Kandidaten bei der Wahl zum Prüfungsausschuss
+## § 8 Wahlvorschläge
 
-(1) Gibt es für die Wahl für das studentische Mitglied im Prüfungsausschuss keinen Kandidaten und hat bis zum Beginn der Stimmabgabe keine wahlberechtigte Person gegenüber der Fachschaft zu verstehen gegeben, für das Amt zur Verfügung zu stehen, so findet abweichend von §2 (3) keine Wahl für das studentische Mitglied im Prüfungsausschuss durch die gesamte Fachschaft statt.
+(1) Die Kandidatur für den Fachschaftsrat sowie für die durch die Fachschaft gewählten studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss erfolgt in Textform. Die Mitteilung über die Kandidatur ist spätestens zwei Wochen vor der Wahl dem Wahlausschuss zuzuleiten. Sie muss Namen und Vornamen, E-Mail-Adresse, Studiengang und falls zutreffend Semesterzahl des Kandidaten enthalten.
+
+(2) Der Wahlausschuss kann eine Verlängerung der Zuleitungsfrist der Wahlvorschläge beschließen, spätestens endet diese aber eine Woche vor der Wahl.
+
+(3) Die Wahlvorschläge werden eine Woche vor der Wahl per E-Mail an die Fachschaft bekanntgegeben.
+
+
+## § 8a Fehlende Kandidaten bei der Wahl zum Prüfungsausschuss
+
+(1) Gibt es für die Wahl für das studentische Mitglied im Prüfungsausschuss keinen Kandidaten und hat bis zum Beginn der Stimmabgabe keine wahlberechtigte Person gegenüber der Fachschaft zu verstehen gegeben, für das Amt zur Verfügung zu stehen, so findet abweichend von § 2 (3) keine Wahl für das studentische Mitglied im Prüfungsausschuss durch die gesamte Fachschaft statt.
 
 (2) Das Amt muss in diesem Fall von einem Mitglied des Fachschaftsrates übernommen werden.
 
-(3) Die Wahl des studentischen Mitglieds im Prüfungsausschuss findet in diesem Fall während der konstituierenden Sitzung des neuen Fachschaftsrates statt. Die §§4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in §5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
+(3) Die Wahl des studentischen Mitglieds im Prüfungsausschuss findet in diesem Fall während der konstituierenden Sitzung des neuen Fachschaftsrates statt. Die §§ 4 bis 12 finden dabei keine Anwendung. Das Verfahren entspricht dem der in §5a der Satzung der Fachschaft IT-Systems Engineering genannten Ämter.
 
 
-## §9 Wahldurchführung
+## § 9 Wahldurchführung
 
-(1)	Jedes Mitglied der Fachschaft hat ebenso viele Stimmen, wie Mitglieder des jeweiligen Gremiums zu wählen sind.
+(1) Jedes Mitglied der Fachschaft hat ebenso viele Stimmen, wie Mitglieder des jeweiligen Gremiums zu wählen sind.
 
-(2)	Dem Wähler steht es offen, seine Stimmen auf die Kandidaten zu verteilen. Stimmenhäufung ist nicht zulässig.
+(2) Dem Wähler steht es offen, seine Stimmen auf die Kandidaten zu verteilen. Stimmenhäufung ist nicht zulässig.
 
-(3)	Der Wähler ist nicht an die Kandidaten gebunden.
+(3) Der Wähler ist nicht an die Kandidaten gebunden.
 
-(4)	Wahlberechtigten wird ab der Bekanntgabe der Kandidaten die Möglichkeit gegeben, ihre Stimme per E-Mail abzugeben. Dieses Verfahren muss einer Briefwahl insofern entsprechen, als abgegebene Stimmen dem Wähler nicht zugeordnet werden dürfen. Dafür ist die Stimmabgabe in einem getrennt von der E-Mail auszuwertenden Anhang zu tätigen. Die Abgabe der Stimmen per E-Mail muss vom HPI-Konto des Wählers erfolgen.
+(4) Wahlberechtigten wird ab der Bekanntgabe der Kandidaten die Möglichkeit gegeben, ihre Stimme per E-Mail abzugeben. Dieses Verfahren muss einer Briefwahl insofern entsprechen, als abgegebene Stimmen dem Wähler nicht zugeordnet werden dürfen. Dafür ist die Stimmabgabe in einem getrennt von der E-Mail auszuwertenden Anhang zu tätigen. Die Abgabe der Stimmen per E-Mail muss vom HPI-Konto des Wählers erfolgen.
 
-(5)	Sofern ein Wähler sowohl per E-Mail als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der E-Mail.
-
-
-## §10 Ergebnisfeststellung
-
-(1)	Nach Abschluss der Wahl stellt der Wahlausschuss die Zahl der für jeden Kandidaten abgegebenen Stimmen fest. Die Stimmenauszählung erfolgt spätestens am dritten Vorlesungstag nach der Wahl. Sie erfolgt öffentlich für alle Mitglieder der Fachschaft und muss durch den Wahlausschuss spätestens zwei Tage vorher per E-Mail an die Fachschaft angekündigt werden.
-
-(2)	In den Fachschaftsrat, die Studienkommission und den Prüfungsausschuss gewählt sind die Personen, die jeweils die meisten Stimmen auf sich vereinen. Sind weniger als die notwendige Anzahl Personen gewählt, sind Neuwahlen notwendig.
-
-(3)	Bei Stimmengleichheit um den letzten Platz entstehen im Fachschaftsrat Überhangmandate. Bei Stimmengleichheit in den Wahlen für die studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss müssen sich die betroffenen Kandidaten mit gleicher Stimmenzahl zusammen mit dem Wahlausschuss auf ein Lösungsverfahren einigen.
-
-(4)	Jede gewählte Person muss dem Wahlausschuss innerhalb einer Woche mitteilen, ob er oder sie die Wahl annimmt. Ansonsten gilt die Annahme als verweigert.
+(5) Sofern ein Wähler sowohl per E-Mail als auch per Wahlzettel abgestimmt hat, verfällt die Stimmabgabe aus der E-Mail.
 
 
-## §11 Bekanntgabe des Wahlergebnisses
+## § 10 Ergebnisfeststellung
+
+(1) Nach Abschluss der Wahl stellt der Wahlausschuss die Zahl der für jeden Kandidaten abgegebenen Stimmen fest. Die Stimmenauszählung erfolgt spätestens am dritten Vorlesungstag nach der Wahl. Sie erfolgt öffentlich für alle Mitglieder der Fachschaft und muss durch den Wahlausschuss spätestens zwei Tage vorher per E-Mail an die Fachschaft angekündigt werden.
+
+(2) In den Fachschaftsrat, die Studienkommission und den Prüfungsausschuss gewählt sind die Personen, die jeweils die meisten Stimmen auf sich vereinen. Sind weniger als die notwendige Anzahl Personen gewählt, sind Neuwahlen notwendig.
+
+(3) Bei Stimmengleichheit um den letzten Platz entstehen im Fachschaftsrat Überhangmandate. Bei Stimmengleichheit in den Wahlen für die studentischen Mitglieder in der Studienkommission und dem Prüfungsausschuss müssen sich die betroffenen Kandidaten mit gleicher Stimmenzahl zusammen mit dem Wahlausschuss auf ein Lösungsverfahren einigen.
+
+(4) Jede gewählte Person muss dem Wahlausschuss innerhalb einer Woche mitteilen, ob er oder sie die Wahl annimmt. Ansonsten gilt die Annahme als verweigert.
+
+
+## § 11 Bekanntgabe des Wahlergebnisses
 
 Der Wahlausschuss gibt die Ergebnisse der Wahl per E-Mail an die Fachschaft bekannt. Er benachrichtigt ferner die gewählten Mitglieder des jeweiligen Gremiums.
 
 
-## §12 Anfechtungsfrist
+## § 12 Anfechtungsfrist
 
-(1)	Die Wahl kann innerhalb einer Woche nach Veröffentlichung des Wahlergebnisses angefochten werden. Eine Anfechtung erfolgt schriftlich unter Angabe der Gründe beim Wahlausschuss. Es kommen nur die in §20 (2) der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Gründe in Betracht.
+(1) Die Wahl kann innerhalb einer Woche nach Veröffentlichung des Wahlergebnisses angefochten werden. Eine Anfechtung erfolgt schriftlich unter Angabe der Gründe beim Wahlausschuss. Es kommen nur die in § 20 (2) der Rahmenwahlordnung der Studierendenschaft der Universität Potsdam vom 8. Mai 2012 aufgeführten Gründe in Betracht.
 
-(2)	Über Zulässigkeit und Folgen der Anfechtung entscheidet der Wahlausschuss.
-
-
-## §13 Wahlordnung der Universität Potsdam
-
-(1)	Diese Wahlordnung ist im Zweifel im Sinne der Bestimmungen der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam auszulegen.
-
-(2)	Soweit diese Wahlordnung eine Regelung nicht enthält, die unabdingbar ist und nicht durch Auslegung ermittelt werden kann, sind die Vorschriften der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam entsprechend anzuwenden.
+(2) Über Zulässigkeit und Folgen der Anfechtung entscheidet der Wahlausschuss.
 
 
-## §14 Änderung der Wahlordnung
+## § 13 Wahlordnung der Universität Potsdam
+
+(1) Diese Wahlordnung ist im Zweifel im Sinne der Bestimmungen der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam auszulegen.
+
+(2) Soweit diese Wahlordnung eine Regelung nicht enthält, die unabdingbar ist und nicht durch Auslegung ermittelt werden kann, sind die Vorschriften der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam entsprechend anzuwenden.
+
+
+## § 14 Änderung der Wahlordnung
 
 (1) Der Fachschaftsrat kann Veränderungen dieser Wahlordnung vornehmen. Ein entsprechender Beschluss bedarf einer Zwei-Drittel-Mehrheit aller Mitglieder des Fachschaftsrates.
 


### PR DESCRIPTION
Inhaltliche Änderungen:
- Das studentische Mitglied im Prüfungsausschuss wird nicht mehr von der gesamten Fachschaft, sondern vom FSR aus dessen Mitte gewählt.
- Beginn der Amtszeit für die gewählten Mitglieder aller Gremien ist die konstituierende Sitzung des FSRs. Bis dahin bleiben die alten Mitglieder kommissarisch im Amt.
- Bei Personen gleichen Namens ist für die Wahl der in der HPI-Domäne geführte Name (mit evtl. nachgestellter Zahl) zu verwenden.
- Bei Briefwahl muss die Stimmabgabe für jedes Gremium in einem eigenen Anhang getätigt werden.
- Die Fristen für die Auszählung der Wahl, die Annahme der gewählten Mitglieder, die Bekanntgabe der Wahlergebnisse und die Einladung zur konstituierenden Sitzung werden verändert.
- Rücktritte und Verfahren für Nachrücker werden für alle Gremien explizit geregelt.
