### PR TITLE
Entwurf Empfehlungswahlordnung zu den Fakultätsgremien

### DIFF
--- a/empfehlungswahlordnung.md
+++ b/empfehlungswahlordnung.md
@@ -1,0 +1,67 @@
+# Empfehlungswahlordnung der Fachschaft IT-Systems Engineering zu studentischen Mitgliedern in Gremien der Digital Engineering Fakultät an der Universität Potsdam
+
+Diese Empfehlungswahlordnung ist am 03.05.2018 durch Beschluss der Vollversammlung in Kraft getreten.
+
+## § 1 Empfehlungswahl
+
+(1) Um das Engagement und die basisdemokratische Legitimation der Mitglieder in den Gremien der Fakultät zu fördern, spricht die Fachschaft IT-Systems Engineering aus ihrer Mitte Empfehlungen für die Besetzung studentischer Mitglieder in Gremien der Digital Engineering Fakultät mit Hilfe von Wahlen aus.
+
+(2) Eine Empfehlungswahl soll zeitgleich mit den Wahlen zu den Gremien der Fachschaft stattfinden.
+
+(3) Empfehlungen verlieren ihre Gültigkeit, wenn von der Fachschaft neue Empfehlungen ausgesprochen werden.
+
+(4) Die Mitglieder des Fakultätsrates der Digital Engineering Fakultät sind als Organ der akademischen Selbstverwaltung nicht an die Empfehlungen der Fachschaft gebunden.
+
+## § 2 Geltungsbereich
+
+(1) Diese Empfehlungswahlordnung gilt für alle Empfehlungswahlen studentischer Mitglieder in Gremien der Digital Engineering Fakultät an der Universität Potsdam.
+
+(2) Ausgenommen von Empfehlungswahlen sind Gremien, die in unmittelbarer Wahl durch die studentischen Mitglieder der Fakultät besetzt werden.
+
+(3) Es sollen insbesondere Empfehlungen zu studentischen Mitgliedern in Studienkommissionen und Prüfungsausschüssen ausgesprochen werden.
+
+## § 3 Anforderungskommunikation mit den studentischen Mitgliedern des Fakultätsrates
+
+(1) Der Wahlausschuss holt von den studentischen Mitgliedern des Fakultätsrates Informationen über die Anzahl der zu besetzenden Positionen ein.
+
+(2) Mögliche Zusatzkriterien, die die studentischen Mitglieder des Fakultätsrates an die Kandidaturen stellen, können erfasst werden.
+
+(3) Für jedes Fakultätsgremium gemäß § 2 (3) soll mindestens eine Empfehlung ausgesprochen werden.
+
+## § 4 Wahlrecht
+
+(1) Wahlberechtigt sind Mitglieder der Fachschaft IT-Systems Engineering.
+
+(2) Doktoranden besitzen für die Studienkommissionen und Prüfungsausschüsse weder aktives noch passives Wahlrecht.
+
+(3) Jede Person hat so viele Stimmen, wie studentische Mitglieder gemäß § 3 in den Gremien zu benennen sind.
+
+## § 5 Regelungen der Wahlordnung der Fachschaft
+
+Für nicht anders in dieser Empfehlungswahlordnung getroffene Bestimmungen, gelten analog die Regelungen der Wahlordnung der Fachschaft IT-Systems Engineering bezüglich Wahlgrundsatz, Wahlausschuss, Ausschreibung, Wahlvorschläge, Wahldurchführung und Anfechtung.
+
+## § 6 Ergebnisfeststellung
+
+(1) Nach Abschluss der Wahl stellt der Wahlausschuss fest, für welche Person wie viele Stimmen abgegeben wurden. Die Stimmenauszählung erfolgt direkt im Anschluss an die Wahl oder am nächsten auf die Wahl folgenden Vorlesungstag. Sie erfolgt öffentlich für alle Mitglieder der Fachschaft und muss durch den Wahlausschuss spätestens zwei Tage vor der Wahl per E-Mail an die Fachschaft angekündigt werden.
+
+(2) Die Anzahl der erreichten Stimmen je Person stellt eine empfohlene Reihenfolge in der Besetzung studentischer Mitglieder in den Fakultätsgremien dar.
+
+(3) Mit dem Ergebnis wird auch eine Empfehlung für Nachrücken und Neubesetzungen in den Fakultätsgremien ausgesprochen.
+
+## § 7 Bekanntgabe des Wahlergebnisses
+
+Nach Feststellung teilt der Wahlausschuss die Ergebnisse spätestens nach einem Vorlesungstag den studentischen Mitgliedern im Fakultätsrat und der Fachschaft mit.
+
+## § 8 Rahmenwahlordnung der Studierendenschaft
+
+(1) Diese Empfehlungswahlordnung ist im Zweifel im Sinne der Bestimmungen der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam auszulegen.
+
+(2) Soweit diese Empfehlungswahlordnung eine Regelung nicht enthält, die unabdingbar ist und nicht durch Auslegung ermittelt werden kann, sind die Vorschriften der aktuellen Rahmenwahlordnung der Studierendenschaft der Universität Potsdam entsprechend anzuwenden.
+
+## § 9 Änderung der Wahlordnung
+
+(1) Die Änderung der Empfehlungswahlordnung kann nur erfolgen, wenn zwei Drittel der bei einer Vollversammlung stimmberechtigten Anwesenden dem Antrag zustimmen.
+
+(2) Der Fachschaftsrat muss die Fachschaft innerhalb von drei Tagen nach dem Beschluss per E-Mail über die Änderung informieren.
+
+(3) Während des Zeitraumes einer Empfehlungswahl gilt die Empfehlungswahlordnung in der zum Beginn des Zeitraumes geltenden Fassung.

--- a/satzung.md
+++ b/satzung.md
@@ -1,6 +1,6 @@
 # Satzung der Fachschaft IT-Systems Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Satzung ist am 14.04.2016 durch Beschluss der Vollversammlung in Kraft getreten.
+Diese Satzung ist am 03.05.2018 durch Beschluss der Vollversammlung in Kraft getreten.
 
 
 
@@ -72,8 +72,13 @@ Zu den Aufgaben des Fachschaftsrates gehören insbesondere:
 
 (2) Der Wahlausschuss wird durch den Fachschaftsrat aus der Mitte der Fachschaft gebildet.
 
-(3) Näheres regelt die Wahlordnung der Fachschaft IT-Systems Engineering.
+(3) Näheres regeln die Wahlordnung und die Empfehlungswahlordnung der Fachschaft IT-Systems Engineering.
 
+## § 5b Empfehlungswahlen zur Besetzung von Fakultätsgremien
+
+(1) Für Studentische Mitglieder in den Gremien der Digital Engineering Fakultät, die vom Fakultätsrat benannt werden, kann die Fachschaft Empfehlungen aussprechen.
+
+(2) Diese Empfehlungen sind mit Hilfe von Wahlen gemäß der Empfehlungswahlordnung der Fachschaft IT-Systems Engineering zu ermitteln.
 
 ## § 6 Finanzen
 


### PR DESCRIPTION
Eine Wahlordnung, die beschreibt wie Empfehlungen der Fachschaft zur Besetzung studentischer Stellen in den Gremien der Digital Engineering Fakultät ermittelt werden.