### PR TITLE
Satzung: Verweis bei Rücktritt/Abwahl korrigiert

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -39,7 +39,7 @@ Die Organe der Fachschaft sind:
 
 (3) Dem Fachschaftsrat gehören in der Regel acht, mindestens jedoch sechs Mitglieder an. Der Fachschaftsrat sollte aus Bachelor- und Masterstudierenden möglichst vieler unterschiedlicher Semester sowie Promovierenden bestehen.
 
-(4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Näheres reglt die Geschäftsordnung.
+(4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Näheres regelt die Geschäftsordnung.
 
 (5) Der Fachschaftsrat gibt sich eine Geschäftsordnung.
 

--- a/satzung.md
+++ b/satzung.md
@@ -39,7 +39,7 @@ Die Organe der Fachschaft sind:
 
 (3) Dem Fachschaftsrat gehören in der Regel acht, mindestens jedoch sechs Mitglieder an. Der Fachschaftsrat sollte aus Bachelor- und Masterstudierenden möglichst vieler unterschiedlicher Semester sowie Promovierenden bestehen.
 
-(4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Dadurch treten die Regelungen entsprechend §4g in Kraft.
+(4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Näheres reglt die Geschäftsordnung.
 
 (5) Der Fachschaftsrat gibt sich eine Geschäftsordnung.
 


### PR DESCRIPTION
Es gibt in der Satzung gar keinen §4g. Bei der Suche habe ich gesehen, dass die Regelungen sich tatsächlich in §9 der Geschäftsordnung befinden. Da es ungewöhnlich ist, direkt mit Ziffer auf untergeordnete Regelungen zuveweisen schlage ich die Änderungen in dieser PR vor.