### PR TITLE
Satzung

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -1,11 +1,11 @@
 # Satzung der Fachschaft Digital Engineering am Hasso-Plattner-Institut an der Universität Potsdam
 
-Diese Satzung ist am 03.05.2021 durch Beschluss der Vollversammlung in Kraft getreten.
+Diese Satzung ist am XX.XX.2026 durch Beschluss der Vollversammlung in Kraft getreten.
 
 
 ## § 1 Geltungsbereich
 
-Alle Studierenden der Universität Potsdam in den Studienfächern IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, Software Systems Engineering und Computer Science sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
+Alle Studierenden der Universität Potsdam in den Studiengängen B.Sc. IT-Systems Engineering, M.Sc. Computer Science, M.Sc. Digital Health, M.Sc. IT-Systems Engineering, M.Sc. Data Engineering, M.Sc. Cybersecurity und M.Sc. Software Systems Engineering sowie alle an der Digital Engineering Fakultät eingeschriebenen Promotionsstudierenden sind Mitglieder der Fachschaft Digital Engineering.
 
 
 ## § 2 Organe
@@ -21,7 +21,7 @@ Die Organe der Fachschaft sind:
 
 (1) Die Vollversammlung der Fachschaft ist das oberste beschlussfassende Organ der Fachschaft. In der Vollversammlung haben alle Mitglieder der Fachschaft Rede-, Antrags- und Stimmrecht.
 
-(2) In jedem Studienjahr soll eine ordentliche Vollversammlung stattfinden. Ordentliche Vollversammlungen werden durch den Fachschaftsrat einberufen.
+(2) In jedem Semester soll eine ordentliche Vollversammlung stattfinden. Ordentliche Vollversammlungen werden durch den Fachschaftsrat einberufen.
 
 (3) Außerordentliche Vollversammlungen können durch den Fachschaftsrat oder durch mindestens 15 Mitglieder der Fachschaft einberufen werden. Verantwortlich für die Durchführung sind die einberufenden Personen.
 
@@ -38,9 +38,9 @@ Die Organe der Fachschaft sind:
 
 (1) Der Fachschaftsrat ist beschlussfähiges und ausführendes Organ der Fachschaft. Er ist an die Satzung und an die Beschlüsse der Vollversammlung gebunden.
 
-(2) Der Fachschaftsrat wird im Normalfall einmal im Jahr am Anfang des Sommersemesters entsprechend der Wahlordnung der Fachschaft Digital Engineering gewählt.
+(2) Der Fachschaftsrat wird im Normalfall jedes Semester abwechselnd zur Hälfte entsprechend der Wahlordnung der Fachschaft Digital Engineering gewählt.
 
-(3) Dem Fachschaftsrat gehören in der Regel acht, mindestens jedoch sechs Mitglieder an. Der Fachschaftsrat sollte aus Bachelor- und Masterstudierenden möglichst vieler unterschiedlicher Semester sowie Promovierenden bestehen.
+(3) Dem Fachschaftsrat gehören in der Regel sechs bis acht, mindestens jedoch vier Mitglieder an. Der Fachschaftsrat sollte aus Bachelor- und Masterstudierenden möglichst vieler unterschiedlicher Semester sowie Promovierenden bestehen.
 
 (4) Der Fachschaftsrat oder einzelne Mitglieder können jederzeit durch Beschluss der Vollversammlung abgewählt werden. Näheres regelt die Geschäftsordnung des Fachschaftsrates.
 

--- a/statutes.md
+++ b/statutes.md
@@ -2,32 +2,32 @@
 
 *This translation is for information purposes only and is not legally binding.*
 
-These Statutes came into effect by resolution of all members at a General Meeting on 03.05.2021.
+These Statutes came into effect by resolution at a General Meeting on 03.05.2021.
 
 
 ## § 1 Scope
 
-Members of the Digital Engineering student body include all students of the University of Potsdam in the subjects IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, Software Systems Engineering, and Computer Science, as well as PhD students enrolled at the Digital Engineering Faculty.
+Members of the Digital Engineering Student Body include all students of the University of Potsdam in the subjects IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, Software Systems Engineering, and Computer Science, as well as PhD students enrolled at the Digital Engineering Faculty.
 
 
 ## § 2 Organization
 
-The organizational components of the student body are:
+The organizational components of the Student Body are:
 
 1.  The General Meeting (Vollversammlung)
-2.  The Student Representative Group (Fachschaftsrat)
-3.  The Election Committee (Wahlausschuss)
+2.  The Student Council (Fachschaftsrat)
+3.  The Election Committee (Wahlausschuss).
 
 
 ## § 3 General Meeting
 
-(1) The General Meeting of the student body is the supreme decision-making entity of the student body. At the General Meeting all members of the student body have the right to speak, submit motions and vote.
+(1) The General Meeting of the Student Body is the supreme decision-making entity of the Student Body. At the General Meeting all members of the Student Body have the right to speak, submit motions and vote.
 
-(2) An ordinary General Meeting shall take place each academic year. The Student Representative Group is responsible for convening the General Meeting.
+(2) An ordinary General Meeting shall take place each academic year. The Student Council is responsible for convening the General Meeting.
 
-(3) Extraordinary General Meetings may be convened by the Student Representative Group or by at least 15 members of the student body. Those who have called the meeting are responsible for its implementation.
+(3) Extraordinary General Meetings may be convened by the Student Council or by at least 15 members of the Student Body. Those who have called the meeting are responsible for its implementation.
 
-(4) Ordinary General Meetings must be announced at least 28 days in advance by e-mail to the student body, extraordinary General Meetings at least 14 days in advance. Independently of this, General Meetings at which changes to the Statutes are to be voted on must be announced at least 28 days in advance.
+(4) Ordinary General Meetings must be announced at least 28 days in advance by e-mail to the Student Body, extraordinary General Meetings at least 14 days in advance. Independently of this, General Meetings at which changes to the Statutes are to be voted on must be announced at least 28 days in advance.
 
 (5) Any General Meeting announced in accordance with the regulations is quorate.
 
@@ -36,54 +36,54 @@ The organizational components of the student body are:
 (7) The General Meeting creates its own Rules of Procedure.
 
 
-## § 4 Student Representative Group
+## § 4 Student Council
 
-(1) The Student Representative Group is a quorate and executive entity of the student body. It is bound by the Statutes and the decisions of the General Meeting.
+(1) The Student Council is a quorate and executive entity of the Student Body. It is bound by the Statutes and the decisions of the General Meeting.
 
-(2) As a rule, the Student Representative Group will be elected once a year at the beginning of the summer semester in accordance with the Electoral Code of the Digital Engineering Student Body.
+(2) As a rule, the Student Council will be elected once a year at the beginning of the summer semester in accordance with the Electoral Code of the Digital Engineering Student Body.
 
-(3) The Student Representative Group usually consists of eight, but at least six, members. Ideally, the Student Representative Group should contain bachelor’s and master’s students in different semesters as well as PhD students.
+(3) The Student Council usually consists of eight, but at least six, members. Ideally, the Student Council should contain bachelor’s and master’s students in different semesters as well as PhD students.
 
-(4) The Student Representative Group or individual members can be removed from office at any time by a resolution of the General Meeting. See the Rules of Procedure of the Student Representative Group for further details.
+(4) The Student Council or individual members can be removed from office at any time by a resolution of the General Meeting. See the Rules of Procedure of the Student Council for further details.
 
-(5) The Student Representative Group creates its own Rules of Procedure.
+(5) The Student Council creates its own Rules of Procedure.
 
 
 ## § 4a Tasks
 
-Among the particular tasks of the Student Representative Group are:
+Among the particular tasks of the Student Council are:
 
-1.  Representation of the student body in the sense of the Statutes of the Student Body of the University of Potsdam,
-2.  Assistance to students from the student body in study-related matters,
+1.  Representation of the Student Body in the sense of the Statutes of the Student Body of the University of Potsdam,
+2.  Assistance to students from the Student Body in study-related matters,
 3.  Collaboration with the Institute in connection with problems in teaching and research, as well as
-4.  Administration of the finances of the student body
+4.  Administration of the finances of the Student Body
 
 
 ## § 4b Meetings
 
-(1) The Student Representative Group will meet once a week during the instructional period of the semester. The date of the regularly occurring meetings shall be announced by email to the student body.
+(1) The Student Council will meet once a week during the lecture period of the semester. The date of the regularly occurring meetings shall be announced by email to the Student Body.
 
-(2) Extraordinary meetings must be announced by email invitation to the student body.
+(2) Extraordinary meetings must be announced by email invitation to the Student Body.
 
 (3) Minutes must be kept at the meetings.
 
-(4) The meetings of the Student Representative Group are open for all members of the student body. Based on a resolution, the public can be excluded. The contents of non-public sessions are to be recorded as separate minutes, and the reason for the confidentiality of the information given in the regular minutes.
+(4) The meetings of the Student Council are open for all members of the Student Body. Based on a resolution, the public can be excluded. The contents of non-public sessions are to be recorded as separate minutes, and the reason for the confidentiality of the information given in the regular minutes.
 
-(5) Further details are regulated by the Rules of Procedure of the Digital Engineering Student Representative Group.
+(5) Further details are regulated by the Rules of Procedure of the Digital Engineering Student Council.
 
 
 ## § 5 Election Committee
 
-(1) The election committee is responsible for the proper preparation and implementation of student body elections.
+(1) The Election Committee is responsible for the proper preparation and implementation of Student Body elections.
 
-(2) The election committee is formed by the Student Representative Group from among student body members.
+(2) The Election Committee is formed by the Student Council from among Student Body members.
 
 (3) Further details are regulated by the Electoral Code of the Digital Engineering Student Body.
 
 
 ## § 6 Finances
 
-(1) The Student Representative Group must adopt a budget at the beginning of the financial year for the use of the student body funds.
+(1) The Student Council must adopt a budget at the beginning of the financial year for the use of the Student Body funds.
 
 (2) Evidence must be kept and recorded on the use of such funds.
 

--- a/statutes.md
+++ b/statutes.md
@@ -2,12 +2,12 @@
 
 *This translation is for information purposes only and is not legally binding.*
 
-These Statutes came into effect by resolution at a General Meeting on 03.05.2021.
+These Statutes came into effect by resolution at a General Meeting on XXXX XX, 2026.
 
 
 ## § 1 Scope
 
-Members of the Digital Engineering Student Body include all students of the University of Potsdam in the subjects IT-Systems Engineering, Data Engineering, Digital Health, Cybersecurity, Software Systems Engineering, and Computer Science, as well as PhD students enrolled at the Digital Engineering Faculty.
+All students at the University of Potsdam enrolled in the B.Sc. IT-Systems Engineering, M.Sc. Computer Science, M.Sc. Digital Health, M.Sc. IT-Systems Engineering, M.Sc. Data Engineering, M.Sc. Cybersecurity, and M.Sc. Software Systems Engineering programs, as well as all PhD students enrolled at the Digital Engineering Faculty, are members of the Digital Engineering Student Body.
 
 
 ## § 2 Organization
@@ -23,7 +23,7 @@ The organizational components of the Student Body are:
 
 (1) The General Meeting of the Student Body is the supreme decision-making entity of the Student Body. At the General Meeting all members of the Student Body have the right to speak, submit motions and vote.
 
-(2) An ordinary General Meeting shall take place each academic year. The Student Council is responsible for convening the General Meeting.
+(2) An ordinary General Meeting shall take place each semester. The Student Council is responsible for convening the General Meeting.
 
 (3) Extraordinary General Meetings may be convened by the Student Council or by at least 15 members of the Student Body. Those who have called the meeting are responsible for its implementation.
 
@@ -40,9 +40,9 @@ The organizational components of the Student Body are:
 
 (1) The Student Council is a quorate and executive entity of the Student Body. It is bound by the Statutes and the decisions of the General Meeting.
 
-(2) As a rule, the Student Council will be elected once a year at the beginning of the summer semester in accordance with the Electoral Code of the Digital Engineering Student Body.
+(2) Half of the Student Council's members are normally elected every semester, in accordance with the Electoral Code of the Digital Engineering Student Body.
 
-(3) The Student Council usually consists of eight, but at least six, members. Ideally, the Student Council should contain bachelor’s and master’s students in different semesters as well as PhD students.
+(3) The Student Council usually has six to eight, but at least four members. Ideally, the Student Council should include Bachelor's and Master's students from as many different semesters as possible, as well as PhD students.
 
 (4) The Student Council or individual members can be removed from office at any time by a resolution of the General Meeting. See the Rules of Procedure of the Student Council for further details.
 


### PR DESCRIPTION
Inhaltliche Änderungen
- § 2 (2): Ordentliche Vollversammlung einmal im Semester statt einmal im Jahr
- § 4 (2): Angleichung mit Wahlordnung: Der FSR wird einmal pro Semester zur Hälfte gewählt statt einmal pro Jahr vollständig
- § 4 (3): Angleichung mit Wahlordnung: Der FSR besteht aus mindestens vier, normalerweise aber sechs bis acht Mitgliedern statt bisher mindestens sechs, normalerweise acht

---

Content Changes
- § 2 (2): Ordinary General Meeting once per semester instead of once per year
- § 4 (2): Alignment with the Electoral Code: Half of the Student Council is elected once per semester instead of the entire Student Council once per year
- § 4 (3): Alignment with the Electoral Code: The Student Council consists of at least four members, but normally six to eight, instead of the previous minimum of six and normally eight